### PR TITLE
Add refresh on return from event items

### DIFF
--- a/src/contributions/events/Events.js
+++ b/src/contributions/events/Events.js
@@ -176,7 +176,10 @@ export default function Events() {
                     year={year}
                     season={season}
                     event={selectedDrillDownEvent}
-                    onReturn={() => {setSelectedDrillDownEvent(undefined);}}
+                    onReturn={() => {
+                            setSelectedDrillDownEvent(undefined);
+                            refreshEvents();
+                    }}
                 />
             </div>}
         </div>


### PR DESCRIPTION
- [x] Have you read the Contributing guide?
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
- [x] Have you formatted / linted your code locally prior to submission?
- [x] Have you written tests for your code changes, as applicable?

## Problem this Solves

When returning from event items we did not refresh the events page, so the item totals didn't match up.

## Describe your Implementation

Added to the arrow function for on return to refresh.