### PR TITLE
Refresh sites and items when adding new events and event items

### DIFF
--- a/src/contributions/event-items/EventItems.js
+++ b/src/contributions/event-items/EventItems.js
@@ -91,8 +91,8 @@ export default function EventItems({event, year, season, onReturn}) {
         }, [event, itemMap]
     );
 
-    useEffect(() => {
-        if (Object.keys(itemMap).length === 0) {
+    const refreshItemMap = useCallback(
+        () => {
             getItems()
             .then((items) => {
                 if (items) {
@@ -103,12 +103,18 @@ export default function EventItems({event, year, season, onReturn}) {
                     setItemMap(itemsObj);
                 }
             });
+        }, []
+    );
+
+    useEffect(() => {
+        if (Object.keys(itemMap).length === 0) {
+            refreshItemMap();
         }
         else {
             refreshEventItems();
         }
         
-    }, [event, itemMap, refreshEventItems]);
+    }, [event, itemMap, refreshEventItems, refreshItemMap]);
 
     return(
         <div>
@@ -136,7 +142,7 @@ export default function EventItems({event, year, season, onReturn}) {
                 event={event}
                 selectedEventItem={selectedEventItem}
                 onHide={() => {setShowPopup(false); setSelectedEventItem(undefined);}}
-                onChange={refreshEventItems}
+                onChange={refreshItemMap}
             />
             <Popup
                 show={!!eventItemToDelete}

--- a/src/contributions/events/Events.js
+++ b/src/contributions/events/Events.js
@@ -108,9 +108,8 @@ export default function Events() {
         }, [year, season, siteMap]
     );
 
-    useEffect(() => {
-        console.log(year, season);
-        if (Object.keys(siteMap).length === 0) {
+    const refreshSiteMap = useCallback(
+        () => {
             getSites()
             .then((sites) => {
                 if (sites) {
@@ -121,12 +120,19 @@ export default function Events() {
                     setSiteMap(sitesObj);
                 }
             });
+        }, []
+    );
+
+    useEffect(() => {
+        console.log(year, season);
+        if (Object.keys(siteMap).length === 0) {
+            refreshSiteMap();
         }
         else {
             refreshEvents();
         }
         
-    }, [year, season, siteMap, refreshEvents]);
+    }, [year, season, siteMap, refreshEvents, refreshSiteMap]);
 
     return(
         <div>
@@ -174,7 +180,7 @@ export default function Events() {
                     events={events}
                     selectedEvent={selectedEditEvent}
                     onHide={() => {setShowPopup(false); setSelectedEditEvent(undefined);}}
-                    onChange={refreshEvents}
+                    onChange={refreshSiteMap}
                 />
                 <Popup
                     show={!!eventToDelete}


### PR DESCRIPTION
<!--
Please be patient, this is for the best. Do the checklist before filing an issue:
-->

- [x] Have you read the Contributing guide?
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
- [ ] Have you formatted / linted your code locally prior to submission?
- [ ] Have you written tests for your code changes, as applicable?

## Problem this Solves
When a user adds a site and then immediately adds an event for that site, the Events page does not show the details of that site because the site data on the Events page did not get refreshed.

## Describe your Implementation
I refresh the cached sites / items whenever a new event or event item is added.
