### PR TITLE
Clear tier2 on de-selection

### DIFF
--- a/src/contributions/ThreeTierSelect.js
+++ b/src/contributions/ThreeTierSelect.js
@@ -83,11 +83,11 @@ export default function ThreeTierSelect({isDisabled, title, allOptions,
         else {
             setSelection({
                 "tier1": selection.tier1,
-                "tier2": selection.tier2,
+                "tier2": {}, // clear tier2 when the selection is cleared
                 "tier3": {}
             });
         }
-    }, [allOptions, selectedId, selection.tier1, selection.tier2, selection.tier3.value, tier1Prop, tier2Prop, tier3Prop, idProp]);
+    }, [allOptions, selectedId, selection.tier1, selection.tier2.value, selection.tier3.value, tier1Prop, tier2Prop, tier3Prop, idProp]);
 
     useEffect(() => {
         console.log("ThreeTierSelect::useEffect selection", selection);


### PR DESCRIPTION
<!--
Please be patient, this is for the best. Do the checklist before filing an issue:
-->

- [x] Have you read the Contributing guide?
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
- [x] Have you formatted / linted your code locally prior to submission?
- [x] Have you written tests for your code changes, as applicable?

## Problem this Solves
COA users would like both the category and item to clear out after an addition.


## Describe your Implementation
Use effect does not handle empty objects as equivalent, so I needed to change the hook to listen to selection.tier2.value (string val) instead of just the selection.tier2 (object). 